### PR TITLE
change get_to_post method for okx estimate-quote

### DIFF
--- a/python/ccxt/okx.py
+++ b/python/ccxt/okx.py
@@ -291,7 +291,7 @@ class okx(Exchange, ImplicitAPI):
                         # convert
                         'asset/convert/currencies': 5 / 3,
                         'asset/convert/currency-pair': 5 / 3,
-                        'asset/convert/estimate-quote': 5,
+                        
                         'asset/convert/trade': 5,
                         'asset/convert/history': 5 / 3,
                         # options
@@ -367,6 +367,8 @@ class okx(Exchange, ImplicitAPI):
                         'broker/nd/subaccount/delete-apikey': 10,
                         'broker/nd/subaccount/modify-apikey': 10,
                         'broker/nd/rebate-per-orders': 36000,
+                        # convert
+                        'asset/convert/estimate-quote': 5,
                         # earn
                         'finance/staking-defi/purchase': 3,
                         'finance/staking-defi/redeem': 3,


### PR DESCRIPTION
As stated in OKX API documentation the estimate-quote endpoint requires a POST method. As of now the 'asset/convert/estimate-quote' is in the GET method list I moved the line from the "get" methods to the "post" methods.